### PR TITLE
chore: go-demo-6 to 1.0.337

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: go-demo-6
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.336
+  version: 1.0.337


### PR DESCRIPTION
chore: Promote go-demo-6 to version 1.0.337